### PR TITLE
adding necessary 'listen' dependency.

### DIFF
--- a/fontcustom.gemspec
+++ b/fontcustom.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'json'
   gem.add_dependency 'thor'
+  gem.add_dependency 'listen'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bundler'


### PR DESCRIPTION
tried to install this tool (cool tool btw) and was getting a dependency error with my ruby installation when running the cool (gem install 'listen' fixed it and works fine).  'watcher.rb' uses the 'listen' library.
