### PR TITLE
Use ttf2eot for IE7 support - closes endtwist/fontcustom#36

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 
 ```sh
 # Requires FontForge
-brew install fontforge eot-utils ttfautohint
+brew install fontforge ttf2eot ttfautohint
 gem install fontcustom
 ```
 

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -82,7 +82,7 @@ except OSError:
 	# sfnt2woff from source, simplifying install.
 	subprocess.call(['sfnt2woff', fontfile + '.ttf'])
 
-subprocess.call('mkeot ' + fontfile + '.ttf > ' + fontfile + '.eot', shell=True)
+subprocess.call('ttf2eot ' + fontfile + '.ttf > ' + fontfile + '.eot', shell=True)
 
 # Hint the TTF file
 subprocess.call('ttfautohint -s -n ' + fontfile + '.ttf ' + fontfile + '-hinted.ttf > /dev/null 2>&1 && mv ' + fontfile + '-hinted.ttf ' + fontfile + '.ttf', shell=True)


### PR DESCRIPTION
Hi,

First off, thank you SO much for this awesome tool.  Like the other users in endtwist/fontcustom#36, I have had trouble using the `eot` fonts generated with `mkeot` in Internet Explorer 7.  Switching to `ttf2eot` has fixed this issue for me.

Installing `ttf2eot` with `brew install ttf2eot` works great on OS X, but threw errors on Ubuntu 12.04.1 LTS (precise).  Luckily [Issue 22](https://code.google.com/p/ttf2eot/issues/detail?id=22) included a patch that solves this error.  The following code installs a working copy of ttf2eot on Ubuntu.

``` bash
curl -O http://ttf2eot.googlecode.com/files/ttf2eot-0.0.2-2.tar.gz && \
    tar --no-same-owner -zxf ttf2eot-0.0.2-2.tar.gz && \
    cd ttf2eot-0.0.2-2 && \
    curl 'http://ttf2eot.googlecode.com/issues/attachment?aid=220001000&name=cstddef.patch&token=UA99q6il-FrbnCsnfkBjWMVa7vk%3A1358417775911' > 22.patch && \
    patch -p1 < 22.patch && \
    make && \
    sudo cp ttf2eot /usr/local/bin/ && \
    cd .. && \
    rm -rf ttf2eot-0.0.2-2 ttf2eot-0.0.2-2.tar.gz
```
