### PR TITLE
Add -t flag to pass in a path to the CSS template

### DIFF
--- a/lib/fontcustom/generator.rb
+++ b/lib/fontcustom/generator.rb
@@ -11,6 +11,7 @@ module Fontcustom
     class_option :output, :aliases => '-o'
     class_option :name, :aliases => '-n'
     class_option :nohash, :type => :boolean, :default => false
+    class_option :template, :aliases => '-t', :default => 'templates/fontcustom.css'
 
     def self.source_root
       File.dirname(__FILE__)
@@ -81,7 +82,7 @@ module Fontcustom
       @classes = files.map {|file| File.basename(file)[0..-5].gsub(/\W/, '-').downcase }
       @path = File.basename(@path)
 
-      template('templates/fontcustom.css', File.join(@output, 'fontcustom.css'))
+      template(options.template, File.join(@output, 'fontcustom.css'))
     end
   end
 end


### PR DESCRIPTION
Hey, Thanks again for this awesome app.  Here's another feature I needed.

I added the [--template <absolute path to template>] and
[--t <absolute path to template>] flags to `fontcustom compile` to allow
for overriding of the default CSS template file.

I'm not very well versed in Ruby, so please feel free to comment and/or modify, but I think it's pretty useful to allow users to override the default `fontcustom.css` template so that it can more specifically meet their needs.

Thanks again!
