### PR TITLE
Added CSS class display to to test.html

### DIFF
--- a/lib/fontcustom/templates/test.html
+++ b/lib/fontcustom/templates/test.html
@@ -92,6 +92,7 @@
       <div class="glyph">
         <div class="fs1" ><i class="icon-<%= name %>"></i></div>
         <input type="text" readonly="readonly" value="&amp;#x<%= (61696+index).to_s(16) %>;" />
+        <input type="text" readonly="readonly" value=".icon-<%= name %>" />
       </div>
     <% end %>
     </section>


### PR DESCRIPTION
Current sample file is very useful, but doesn't show the name (or CSS class) of each glyph. Added an second textbox for each glyph in test.html so that CSS class can be viewed/copied.

Thanks for an incredibly useful gem.
