### PR TITLE
Set glyph widths automatically

### DIFF
--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -75,14 +75,18 @@ for dirname, dirnames, filenames in os.walk(indir):
 
 			# glyph.left_side_bearing = KERNING
 			# glyph.right_side_bearing = KERNING
-			glyph.width = 512
+			#glyph.width = 512
 
 			# possible optimization?
 			# glyph.simplify()
 			# glyph.round()
+			glyph.left_side_bearing = glyph.right_side_bearing = 0
+			glyph.round()
 
 			files.append(name)
 			cp += 1
+
+		f.autoWidth(0, 0, 512)
 
 if args.nohash:
 	fontfile = outdir + '/' + args.name


### PR DESCRIPTION
fontcustom sets every glyph width to 512.

That's a problem: a right-pointing chevron might have a width of 200, for instance; and when the glyph is set in a `text-align: right;` container, we'd expect it to align all the way to the right.

The solution is to let fontforge figure out glyph widths and write them to the font. This patch does the trick: notice, in generated svg fonts, the new "horiz-adv-x" entries.

This shouldn't have any dramatic negative consequences on users' existing fonts unless users are setting the wrong margins/paddings in their CSS because the icons have the wrong width. And if that's the case, it's probably better to fix this as soon as possible.
