### PR TITLE
Adding support for using HTML entities with data-icon HTML attributes

### DIFF
--- a/lib/fontcustom/templates/fontcustom.css
+++ b/lib/fontcustom/templates/fontcustom.css
@@ -13,6 +13,19 @@
   font-style: normal;
 }
 
+[data-icon]:before {
+  font-family: "<%= @opts[:font_name] %>";
+  content: attr(data-icon);
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  text-decoration: inherit;
+}
+
 <%= @glyphs.map {|name| ".#{@opts.css_prefix + name}:before"}.join(",\n") %> {
   font-family: "<%= @opts.font_name %>";
   font-style: normal;


### PR DESCRIPTION
Generated CSS will not support HTML entities via the data attribute, i.e.:

``` html
<h1 data-icon="&#xf101;">I love bacon</h1>
```
