### PR TITLE
fix autohint

### DIFF
--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -122,7 +122,7 @@ subprocess.call('python ' + scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -
 subprocess.call('mv ' + fontfile + '.eotlite ' + fontfile + '.eot', shell=True)
 
 # Hint the TTF file
-subprocess.call('ttfautohint -s -n ' + fontfile + '.ttf ' + fontfile + '-hinted.ttf > /dev/null 2>&1 && mv ' + fontfile + '-hinted.ttf ' + fontfile + '.ttf', shell=True)
+subprocess.call('ttfautohint -s -f -n ' + fontfile + '.ttf ' + fontfile + '-hinted.ttf > /dev/null 2>&1 && mv ' + fontfile + '-hinted.ttf ' + fontfile + '.ttf', shell=True)
 
 # Describe output in JSON
 outname = os.path.basename(fontfile)


### PR DESCRIPTION
ttfautohint uses a noop hinter for glyphs in the private use area
http://www.freetype.org/ttfautohint/doc/ttfautohint.html#scripts
unless you specify the fallback option:
http://www.freetype.org/ttfautohint/doc/ttfautohint.html#fallback-script

This is suggested in the documentation for --symbol "Use this option
(usually in combination with option --latin-fallback) to hint symbol"

Before this change if you opened the generated font in FontForge
and looked at a glyph then Hint > Edit Instructions there would be
no instructions, after adding this flag, the glyph will have instructions
added.
