### PR TITLE
Relax json version requirement

### DIFF
--- a/fontcustom.gemspec
+++ b/fontcustom.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "json", "~>1.8.0"
+  gem.add_dependency "json", "~>1.7"
   gem.add_dependency "thor", "~>0.18.1"
   gem.add_dependency "listen", "~>1.3.1"
 


### PR DESCRIPTION
It seems that 1.8 isn't a requirement for FontCustom and it's preventing it from working on our older Rails application. Relax the version requirement.
