### PR TITLE
Add configurable autowidth to allow creation of stacking icon sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ preprocessor_path: ""                 # Font path used in CSS proprocessor templ
 data_cache: (same as fontcustom.yml)  # Sets location of data file
 debug: false                          # Output raw messages from fontforge
 quiet: false                          # Silence all output messages
+autowidth: true                       # Automatically size glyphs based on the width of their individual vectors
 templates: [ css, preview ]           # Templates to generate alongside fonts
                                       # Possible values: preview, css, scss, scss-rails, bootstrap, 
                                       # bootstrap-scss, bootstrap-ie7, bootstrap-ie7-scss

--- a/lib/fontcustom.rb
+++ b/lib/fontcustom.rb
@@ -42,6 +42,7 @@ module Fontcustom
     :css_prefix => "icon-",
     :data_cache => nil,
     :preprocessor_path => nil,
+    :autowidth => true,
     :no_hash => false,
     :debug => false,
     :quiet => false

--- a/lib/fontcustom/cli.rb
+++ b/lib/fontcustom/cli.rb
@@ -41,6 +41,10 @@ module Fontcustom
     class_option :preprocessor_path, :aliases => "-s", :type => :string,
       :desc => "Optional font path for CSS proprocessor templates."
 
+    class_option :autowidth, :aliases => "-a", :type => :boolean,
+      :desc => "Auto-size glyphs to their individual vector widths.",
+      :default => DEFAULT_OPTIONS[:autowidth]
+
     class_option :no_hash, :aliases => "-h", :type => :boolean,
       :desc => "Generate fonts without asset-busting hashes."
 

--- a/lib/fontcustom/generator/font.rb
+++ b/lib/fontcustom/generator/font.rb
@@ -54,7 +54,8 @@ module Fontcustom
       end
 
       def generate
-        cmd = "fontforge -script #{Fontcustom.gem_lib}/scripts/generate.py #{opts.input[:vectors]} #{opts.output[:fonts]} --name #{opts.font_name}" 
+        cmd = "fontforge -script #{Fontcustom.gem_lib}/scripts/generate.py #{opts.input[:vectors]} #{opts.output[:fonts]} --name #{opts.font_name}"
+        cmd += " --autowidth" if opts.autowidth
         cmd += " --nohash" if opts.no_hash
         cmd += " --debug" if opts.debug
         output, err, status = execute_and_clean(cmd)

--- a/lib/fontcustom/options.rb
+++ b/lib/fontcustom/options.rb
@@ -8,7 +8,7 @@ module Fontcustom
   class Options
     include Util
 
-    attr_reader :project_root, :input, :output, :config, :templates, :font_name, :css_prefix, :data_cache, :preprocessor_path, :no_hash, :debug, :quiet, :skip_first 
+    attr_reader :project_root, :input, :output, :config, :templates, :font_name, :css_prefix, :data_cache, :preprocessor_path, :autowidth, :no_hash, :debug, :quiet, :skip_first
 
     def initialize(options = {})
       check_fontforge
@@ -95,7 +95,7 @@ module Fontcustom
       remove_instance_variable :@cli_options
 
       # :config is excluded since it's already been set
-      keys = %w|project_root input output data_cache templates font_name css_prefix preprocessor_path skip_first no_hash debug quiet|
+      keys = %w|project_root input output data_cache templates font_name css_prefix preprocessor_path skip_first autowidth no_hash debug quiet|
       keys.each { |key| instance_variable_set("@#{key}", options[key.to_sym]) }
 
       @font_name = @font_name.strip.gsub(/\W/, "-")

--- a/lib/fontcustom/templates/fontcustom.yml
+++ b/lib/fontcustom/templates/fontcustom.yml
@@ -11,6 +11,10 @@
 #debug: false
 #quiet: false
 
+# setting this to false allows the creation of stacking icons, since all glyphs
+# will retain their original positions.
+#autowidth: true
+
 
 # ---------------------------------------------------------------------------- #
 # Project Paths


### PR DESCRIPTION
This allows the user to disable automatic glyph width sizing, which was added in #95. This behavior is useful when creating fonts meant to be stacked, such as http://intridea.github.io/stately/.

It defaults to `true`, to preserve the current behavior.
