### PR TITLE
Reorder font face urls in templates

### DIFF
--- a/lib/fontcustom/templates/_fontcustom-bootstrap.scss
+++ b/lib/fontcustom/templates/_fontcustom-bootstrap.scss
@@ -14,6 +14,13 @@
   font-style: normal;
 }
 
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  @font-face {
+    font-family: "<%= @opts.font_name %>";
+    src: url("<%= @font_path_alt %>.svg#<%= @opts.font_name %>") format("svg");
+  }
+}
+
 [class^="<%= @opts.css_prefix %>"]:before, [class*=" <%= @opts.css_prefix %>"]:before {
   font-family: "<%= @opts.font_name %>";
   font-weight: normal;

--- a/lib/fontcustom/templates/_fontcustom-rails.scss
+++ b/lib/fontcustom/templates/_fontcustom-rails.scss
@@ -13,6 +13,13 @@
   font-style: normal;
 }
 
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  @font-face {
+    font-family: "<%= @opts.font_name %>";
+    src: url("<%= @font_path_alt %>.svg#<%= @opts.font_name %>") format("svg");
+  }
+}
+
 [data-icon]:before { content: attr(data-icon); }
 
 [data-icon]:before,

--- a/lib/fontcustom/templates/_fontcustom.scss
+++ b/lib/fontcustom/templates/_fontcustom.scss
@@ -13,6 +13,13 @@
   font-style: normal;
 }
 
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+  @font-face {
+    font-family: "<%= @opts.font_name %>";
+    src: url("<%= @font_path_alt %>.svg#<%= @opts.font_name %>") format("svg");
+  }
+}
+
 [data-icon]:before { content: attr(data-icon); }
 
 [data-icon]:before,

--- a/lib/fontcustom/templates/fontcustom-bootstrap.css
+++ b/lib/fontcustom/templates/fontcustom-bootstrap.css
@@ -14,6 +14,13 @@
   font-style: normal;
 }
 
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+    @font-face {
+        font-family: "<%= @opts.font_name %>";
+        src: url("<%= @font_path %>.svg#<%= @opts.font_name %>") format("svg");
+    }
+}
+
 [class^="<%= @opts.css_prefix %>"]:before, [class*=" <%= @opts.css_prefix %>"]:before {
   font-family: "<%= @opts.font_name %>";
   font-weight: normal;

--- a/lib/fontcustom/templates/fontcustom-preview.html
+++ b/lib/fontcustom/templates/fontcustom-preview.html
@@ -132,6 +132,13 @@
         font-style: normal;
       }
 
+      @media screen and (-webkit-min-device-pixel-ratio:0) {
+          @font-face {
+              font-family: "<%= @opts.font_name %>";
+              src: url("<%= @font_path_preview %>.svg#<%= @opts.font_name %>") format("svg");
+          }
+      }
+
       [data-icon]:before { content: attr(data-icon); }
 
       [data-icon]:before,

--- a/lib/fontcustom/templates/fontcustom.css
+++ b/lib/fontcustom/templates/fontcustom.css
@@ -13,6 +13,13 @@
   font-style: normal;
 }
 
+@media screen and (-webkit-min-device-pixel-ratio:0) {
+    @font-face {
+        font-family: "<%= @opts.font_name %>";
+        src: url("<%= @font_path %>.svg#<%= @opts.font_name %>") format("svg");
+    }
+}
+
 [data-icon]:before { content: attr(data-icon); }
 
 [data-icon]:before,


### PR DESCRIPTION
Move svg font face to the top of the list of font face options to reduce pixelation of fonts in Chrome on Windows.

Before:
![screen shot 2013-11-08 at 2 06 09 pm](https://f.cloud.github.com/assets/38108/1503291/e29cc90e-48a8-11e3-9bb0-2262b1286cf6.png)

After:
![screen shot 2013-11-08 at 2 06 16 pm](https://f.cloud.github.com/assets/38108/1503293/ee91ca3e-48a8-11e3-978d-db92f15f9ab2.png)
