### PR TITLE
Improve autohinting on all fonts, not just ttf

### DIFF
--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -109,6 +109,9 @@ svgfile.seek(0)
 svgfile.write(svgtext.replace('''<svg>''', '''<svg xmlns="http://www.w3.org/2000/svg">'''))
 svgfile.close()
 
+# Hint the TTF file
+subprocess.call('ttfautohint -s -f -n -W ' + fontfile + '.ttf ' + fontfile + '-hinted.ttf > /dev/null 2>&1 && mv ' + fontfile + '-hinted.ttf ' + fontfile + '.ttf', shell=True)
+
 scriptPath = os.path.dirname(os.path.realpath(__file__))
 try:
     subprocess.Popen([scriptPath + '/sfnt2woff', fontfile + '.ttf'], stdout=subprocess.PIPE)
@@ -121,9 +124,6 @@ except OSError:
 # eotlitetool.py script to generate IE7-compatible .eot fonts
 subprocess.call('python ' + scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -o ' + fontfile + '.eot', shell=True)
 subprocess.call('mv ' + fontfile + '.eotlite ' + fontfile + '.eot', shell=True)
-
-# Hint the TTF file
-subprocess.call('ttfautohint -s -f -n -W ' + fontfile + '.ttf ' + fontfile + '-hinted.ttf > /dev/null 2>&1 && mv ' + fontfile + '-hinted.ttf ' + fontfile + '.ttf', shell=True)
 
 # Describe output in JSON
 outname = os.path.basename(fontfile)


### PR DESCRIPTION
This change significantly improves font clarity for eot files on windows XP (GDI ClearType) and brings minor improvements in windows 7+ (DirectWrite ClearType) by enabling windows compatibility mode on ttfautohint and by moving the ttfautohint before any other fonts are generated from the original ttf, specifically eot and woff. This also has the benefit of adding type hinting to woff files which are used in windows chrome browsers, notorious for pixelated glyphs. You should see a marked improvement here as well. 

Some downsides to adding type hinting to these file types is that it will increase file size. However, due to the small size of fonts anyway I think this is a worthy tradeoff. A test font collection of mine including 110 glyphs increased eot from 20k to 35k uncompressed and woff from 12k to 20k uncompressed. svg and ttf file sizes are not impacted. 
