### PR TITLE
sprockets allow to find fonts inside `config.assets.paths`. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## EDGE
+
+* Add possibility to not use any prefixes for font name inside css files. `preprocessor_path` option can be `false`
+
 ## 1.3.0 (12/24/2013)
 
 **If upgrading from 1.2.0, delete your old `.fontcustom-manifest.json` and output directories first.**

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ autowidth: false                      # Automatically size glyphs based on the w
 templates: [ css, preview ]           # List of templates to generate alongside fonts
                                       # Possible values: preview, css, scss, scss-rails
 css_selector: .icon-{{glyph}}         # CSS selector format (`{{glyph}}` is replaced)
-preprocessor_path: ""                 # Font path used in CSS proprocessor templates
+preprocessor_path: ""                 # Font path used in CSS proprocessor templates. Use `false` for just font name without any prefixes
 
 # Custom templates should live in the `input` 
 # or `input[:templates]` directory and be added

--- a/lib/fontcustom/generator/template.rb
+++ b/lib/fontcustom/generator/template.rb
@@ -36,7 +36,11 @@ module Fontcustom
         css_path = Pathname.new @options[:output][:css]
         preview_path = Pathname.new @options[:output][:preview]
         @font_path = File.join fonts_path.relative_path_from(css_path).to_s, name
-        @font_path_alt = @options[:preprocessor_path].nil? ? @font_path : File.join(@options[:preprocessor_path], name)
+        @font_path_alt = case @options[:preprocessor_path]
+          when nil then @font_path
+          when false then name
+          else File.join(@options[:preprocessor_path], name)
+        end
         @font_path_preview = File.join fonts_path.relative_path_from(preview_path).to_s, name
       end
 


### PR DESCRIPTION
Add possibility to use font name without any leader relative path prefix. I suggest to allow `false` as `preprocessor_path` option to not insert any prefixes.
