### PR TITLE
Handle preprocessor_path == ""

### DIFF
--- a/lib/fontcustom/generator/template.rb
+++ b/lib/fontcustom/generator/template.rb
@@ -36,7 +36,8 @@ module Fontcustom
         css_path = Pathname.new @options[:output][:css]
         preview_path = Pathname.new @options[:output][:preview]
         @font_path = File.join fonts_path.relative_path_from(css_path).to_s, name
-        @font_path_alt = @options[:preprocessor_path].nil? ? @font_path : File.join(@options[:preprocessor_path], name)
+        @font_path_alt = @options[:preprocessor_path].nil? ? @font_path : 
+          (@options[:preprocessor_path].empty? ? name : File.join(@options[:preprocessor_path], name))
         @font_path_preview = File.join fonts_path.relative_path_from(preview_path).to_s, name
       end
 


### PR DESCRIPTION
When using the asset pipepline, the font-url helper need to receive the name of the font width a slash in the beginning to properly compile assets.

This modifications adds a new ternary to handle the case where preprocessor_path is "" and don't put a slash with the name.
