### PR TITLE
Expose codepoints via SCSS variables

### DIFF
--- a/lib/fontcustom/generator/template.rb
+++ b/lib/fontcustom/generator/template.rb
@@ -157,6 +157,22 @@ module Fontcustom
         end
         output.join "\n"
       end
+
+      def scss_var(name)
+        "$#{font_name}-#{name.to_s}"
+      end
+
+      def glyph_vars_scss
+        @glyphs.map do |name, value|
+          %Q|#{scss_var(name)}: "\\#{value[:codepoint].to_s(16)}";|
+        end.join "\n"
+      end
+
+      def glyphs_scss
+        glyph_vars_scss + "\n" + @glyphs.map do |name, value|
+          %Q|#{@options[:css_selector].sub('{{glyph}}', name.to_s)}:before { content: #{scss_var(name)}}|
+        end.join("\n")
+      end
     end
   end
 end

--- a/lib/fontcustom/templates/_fontcustom.scss
+++ b/lib/fontcustom/templates/_fontcustom.scss
@@ -20,4 +20,4 @@
   -webkit-font-smoothing: antialiased;
 }
 
-<%= glyphs %>
+<%= glyphs_scss %>


### PR DESCRIPTION
The allows easily creating custom icon elements from SCSS that includes the generated file.

For example, given a font name of "my-icon-font" with an icon named "user", the icon can be added to any selector:

```scss
#my-custom-el {
  font-family: "my-icon-font",
  content: $my-icon-font-user;
}
```