### PR TITLE
Fixing scss_template to use regular url attribute, not rails font-url

### DIFF
--- a/lib/fontcustom/templates/_fontcustom.scss
+++ b/lib/fontcustom/templates/_fontcustom.scss
@@ -2,7 +2,7 @@
 // Icon Font: <%= font_name %>
 //
 
-<%= font_face(:preprocessor) %>
+<%= font_face %>
 
 [data-icon]:before { content: attr(data-icon); }
 


### PR DESCRIPTION
'font-url' is only for rails asset pipeline and should only be in the rails scss template.

Fixes #186
