### PR TITLE
don't open source svg for writing

### DIFF
--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -48,14 +48,13 @@ KERNING = 15
 #
 
 def removeSwitchFromSvg( file ):
-    svgfile = open(file, 'r+')
-    tmpsvgfile = tempfile.NamedTemporaryFile(suffix=".svg", delete=False)
+    svgfile = open(file, 'r')
     svgtext = svgfile.read()
-    svgfile.seek(0)
+    svgfile.close()
+    tmpsvgfile = tempfile.NamedTemporaryFile(suffix=".svg", delete=False)
     svgtext = svgtext.replace('<switch>', '')
     svgtext = svgtext.replace('</switch>', '')
     tmpsvgfile.file.write(svgtext)
-    svgfile.close()
     tmpsvgfile.file.close()
 
     return tmpsvgfile.name


### PR DESCRIPTION
while working on a setup where fontcustom was used in a context where it doesn't have write-permission on the source images, I noticed that it's still opening the source files for writing.

In-fact, I believe that `removeSwitchFromSvg` was at some point working on the original file, but later was switched to act on a temporary file.

As such, both the `r+` read mode and the `seek(0)` on the source file were not needed at all.

By changing to just `r` mode (and removing the unneeded `seek`), fontcustom now doesn't need write-access to the source images any more.
