### PR TITLE
Fixed compatiblity issues by removing version numbers in gemspec

### DIFF
--- a/fontcustom.gemspec
+++ b/fontcustom.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "json", "~>1.4"
-  gem.add_dependency "thor", "~>0.14"
-  gem.add_dependency "listen", "~>1.0"
+  gem.add_dependency "json"
+  gem.add_dependency "thor"
+  gem.add_dependency "listen"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "bundler"


### PR DESCRIPTION
I ran into problems with adding the gem to a Gemfile in rails with rspec. We use rspec 3 in our project and with removing the version numbers it worked like a charm.
