### PR TITLE
Fix for an issue where a CSS comment is also a valid base64 encoding.

### DIFF
--- a/lib/fontcustom/generator/template.rb
+++ b/lib/fontcustom/generator/template.rb
@@ -130,7 +130,7 @@ module Fontcustom
   font-family: "#{font_name}";
   src: #{url}("#{path}.eot");
   src: #{url}("#{path}.eot?#iefix") format("embedded-opentype"),
-       #{url}(#{woff_data_uri}),
+       #{url}("#{woff_data_uri}"),
        #{url}("#{path}.woff") format("woff"),
        #{url}("#{path}.ttf") format("truetype"),
        #{url}("#{path}.svg##{font_name}") format("svg");


### PR DESCRIPTION
`//` (a CSS comment) is the base64 encoding of `0xFFF`, and as such a file containing `0xFFF` will cut off everything before the end of the line. This is solved by quoting the data URI.
