### PR TITLE
Build instructions have wrong package name

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
           <p>To install on <strong>OS X</strong> using <strong><a href="http://mxcl.github.com/homebrew/">Homebrew</a></strong> simply run:</p>
           <pre class="prettyprint linenums">
 brew install fontforge --with-python
-brew install eot-tools
+brew install eot-utils
 gem install fontcustom</pre>
 
           <p>On <strong>Linux</strong>? No problem*:</p>


### PR DESCRIPTION
Not called eot-tools, called eot-utils
