### PR TITLE
Correct fontconfig.yml template autowidth default.

### DIFF
--- a/lib/fontcustom/templates/fontcustom.yml
+++ b/lib/fontcustom/templates/fontcustom.yml
@@ -93,4 +93,4 @@
 #font_descent: 64
 
 # Horizontally fit glyphs to their individual vector widths.
-#autowidth: true
+#autowidth: false


### PR DESCRIPTION
The actual default value is `false`, as of b76f6d2.

In 3e14834, the template config file (but not the actual value) was changed back to `true`.
