### PR TITLE
Fix for incorrect output files if directory contains 'fontcustom'.

### DIFF
--- a/lib/fontcustom/generator/template.rb
+++ b/lib/fontcustom/generator/template.rb
@@ -100,7 +100,7 @@ module Fontcustom
         end
 
         if packaged.include?(base) && @options[:font_name] != DEFAULT_OPTIONS[:font_name]
-          target.sub! DEFAULT_OPTIONS[:font_name], @options[:font_name]
+          target = File.join(File.dirname(target), File.basename(target).sub(DEFAULT_OPTIONS[:font_name], @options[:font_name]))
         end
 
         target

--- a/spec/fontcustom/generator/template_spec.rb
+++ b/spec/fontcustom/generator/template_spec.rb
@@ -96,4 +96,21 @@ describe Fontcustom::Generator::Template do
       expect(gen.send(:font_face)).to match("x-font-woff")
     end
   end
+
+  context ".get_target_path" do
+    it "should generate the correct preview target when using default font_name" do
+      gen = Fontcustom::Generator::Template.new fixture("generators/.fontcustom-manifest.json")
+      options = gen.instance_variable_get :@options
+      options[:output] = {:fonts => fixture("sandbox/test/fonts"), :preview => fixture("sandbox/test")}
+      expect(gen.send(:get_target_path, "sandbox/test/fontcustom-preview.html")).to match("/sandbox/test/fontcustom-preview.html")
+    end
+    it "should generate the correct preview target when using custom font_name with output directory containing 'fontcustom'" do
+      gen = Fontcustom::Generator::Template.new fixture("generators/.fontcustom-manifest.json")
+      options = gen.instance_variable_get :@options
+      options[:font_name] = 'custom'
+      options[:output] = {:fonts => fixture("sandbox/test-fontcustom/fonts"), :preview => fixture("sandbox/test-fontcustom")}
+      expect(gen.send(:get_target_path, "sandbox/test/fontcustom-preview.html")).to match("/sandbox/test-fontcustom/custom-preview.html")
+    end
+  end
+
 end


### PR DESCRIPTION
If using a custom font_name in a situation where the output directory contains 'fontcustom' the CSS and preview files would be written to the wrong directory.  This was caused by an incorrect string replacement which was trying to rename "fontcustom-preview.html" to "icon-preview.html" (assuming font_name=icon).  Instead of doing the above the string replacement was replacing part of the directory path. This patch fixes that. Tests included. See #202 as well.