### PR TITLE
Fixed 'unexpected token' error when using brackets in paths

### DIFF
--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -122,8 +122,8 @@ try:
 
     # Convert EOT for IE7
     subprocess.call('python ' + scriptPath + '/eotlitetool.py \'' + fontfile + '.ttf\' -o \'' + fontfile + '.eot\'', shell=True)
-    subprocess.call('mv ' + fontfile + '.eotlite ' + fontfile + '.eot', shell=True)
-    manifest['fonts'].append(fontfile + '.eot')
+    subprocess.call('mv \'' + fontfile + '.eotlite\' \'' + fontfile + '.eot\'', shell=True)
+    manifest['fonts'].append('\'' + fontfile + '.eot\'')
 
 finally:
     manifestfile.seek(0)

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 import tempfile
 import json
-import re
 
 #
 # Manifest / Options
@@ -96,9 +95,6 @@ try:
     if not options['no_hash']:
         fontfile += '_' + manifest['checksum']['current'][:32]
 
-    # Escape brackets
-    fontfile = re.sub(r'([()])', r'\\\1', fontfile)
-
     # Generate TTF and SVG
     font.generate(fontfile + '.ttf')
     font.generate(fontfile + '.svg')
@@ -125,8 +121,8 @@ try:
     manifest['fonts'].append(fontfile + '.woff')
 
     # Convert EOT for IE7
-    subprocess.call('python ' + scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -o ' + fontfile + '.eot', shell=True)
-    subprocess.call('mv ' + fontfile + '.eotlite ' + fontfile + '.eot', shell=True)
+    subprocess.call('python ' + scriptPath + '/eotlitetool.py \'' + fontfile + '.ttf\' -o \'' + fontfile + '.eot\'', shell=True)
+    subprocess.call('mv \'' + fontfile + '.eotlite\' \'' + fontfile + '.eot\'', shell=True)
     manifest['fonts'].append(fontfile + '.eot')
 
 finally:

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -97,7 +97,7 @@ try:
         fontfile += '_' + manifest['checksum']['current'][:32]
 
     # Escape brackets
-    fontfile.sub(r'([()])', r'\\\1', s)
+    re.sub(r'([()])', r'\\\1', fontfile)
 
     # Generate TTF and SVG
     font.generate(fontfile + '.ttf')

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -121,7 +121,7 @@ try:
     manifest['fonts'].append(fontfile + '.woff')
 
     # Convert EOT for IE7
-    subprocess.call('python ' + scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -o ' + fontfile + '.eot', shell=True)
+    subprocess.call('python ' + scriptPath + '/eotlitetool.py \'' + fontfile + '.ttf\' -o \'' + fontfile + '.eot\'', shell=True)
     subprocess.call('mv ' + fontfile + '.eotlite ' + fontfile + '.eot', shell=True)
     manifest['fonts'].append(fontfile + '.eot')
 

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -97,7 +97,7 @@ try:
         fontfile += '_' + manifest['checksum']['current'][:32]
 
     # Escape brackets
-    re.sub(r'([()])', r'\\\1', fontfile)
+    fontfile = re.sub(r'([()])', r'\\\1', fontfile)
 
     # Generate TTF and SVG
     font.generate(fontfile + '.ttf')

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -96,14 +96,14 @@ try:
         fontfile += '_' + manifest['checksum']['current'][:32]
 
     # Generate TTF and SVG
-    font.generate(fontfile + '.ttf')
-    font.generate(fontfile + '.svg')
-    manifest['fonts'].append(fontfile + '.ttf')
-    manifest['fonts'].append(fontfile + '.svg')
+    font.generate('\'' + fontfile + '.ttf\'')
+    font.generate('\'' + fontfile + '.svg\'')
+    manifest['fonts'].append('\'' + fontfile + '.ttf\'')
+    manifest['fonts'].append('\'' + fontfile + '.svg\'')
 
     # Fix SVG header for webkit
     # from: https://github.com/fontello/font-builder/blob/master/bin/fontconvert.py
-    svgfile = open(fontfile + '.svg', 'r+')
+    svgfile = open('\'' + fontfile + '.svg\'', 'r+')
     svgtext = svgfile.read()
     svgfile.seek(0)
     svgfile.write(svgtext.replace('''<svg>''', '''<svg xmlns="http://www.w3.org/2000/svg">'''))
@@ -112,13 +112,13 @@ try:
     # Convert WOFF
     scriptPath = os.path.dirname(os.path.realpath(__file__))
     try:
-        subprocess.Popen([scriptPath + '/sfnt2woff', fontfile + '.ttf'], stdout=subprocess.PIPE)
+        subprocess.Popen([scriptPath + '/sfnt2woff', '\'' + fontfile + '.ttf\''], stdout=subprocess.PIPE)
     except OSError:
         # If the local version of sfnt2woff fails (i.e., on Linux), try to use the
         # global version. This allows us to avoid forcing OS X users to compile
         # sfnt2woff from source, simplifying install.
-        subprocess.call(['sfnt2woff', fontfile + '.ttf'])
-    manifest['fonts'].append(fontfile + '.woff')
+        subprocess.call(['sfnt2woff', '\'' + fontfile + '.ttf\''])
+    manifest['fonts'].append('\'' + fontfile + '.woff\'')
 
     # Convert EOT for IE7
     subprocess.call('python ' + scriptPath + '/eotlitetool.py \'' + fontfile + '.ttf\' -o \'' + fontfile + '.eot\'', shell=True)

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import tempfile
 import json
+import re
 
 #
 # Manifest / Options
@@ -95,15 +96,18 @@ try:
     if not options['no_hash']:
         fontfile += '_' + manifest['checksum']['current'][:32]
 
+    # Escape brackets
+    fontfile.sub(r'([()])', r'\\\1', s)
+
     # Generate TTF and SVG
-    font.generate('\'' + fontfile + '.ttf\'')
-    font.generate('\'' + fontfile + '.svg\'')
-    manifest['fonts'].append('\'' + fontfile + '.ttf\'')
-    manifest['fonts'].append('\'' + fontfile + '.svg\'')
+    font.generate(fontfile + '.ttf')
+    font.generate(fontfile + '.svg')
+    manifest['fonts'].append(fontfile + '.ttf')
+    manifest['fonts'].append(fontfile + '.svg')
 
     # Fix SVG header for webkit
     # from: https://github.com/fontello/font-builder/blob/master/bin/fontconvert.py
-    svgfile = open('\'' + fontfile + '.svg\'', 'r+')
+    svgfile = open(fontfile + '.svg', 'r+')
     svgtext = svgfile.read()
     svgfile.seek(0)
     svgfile.write(svgtext.replace('''<svg>''', '''<svg xmlns="http://www.w3.org/2000/svg">'''))
@@ -112,18 +116,18 @@ try:
     # Convert WOFF
     scriptPath = os.path.dirname(os.path.realpath(__file__))
     try:
-        subprocess.Popen([scriptPath + '/sfnt2woff', '\'' + fontfile + '.ttf\''], stdout=subprocess.PIPE)
+        subprocess.Popen([scriptPath + '/sfnt2woff', fontfile + '.ttf'], stdout=subprocess.PIPE)
     except OSError:
         # If the local version of sfnt2woff fails (i.e., on Linux), try to use the
         # global version. This allows us to avoid forcing OS X users to compile
         # sfnt2woff from source, simplifying install.
-        subprocess.call(['sfnt2woff', '\'' + fontfile + '.ttf\''])
-    manifest['fonts'].append('\'' + fontfile + '.woff\'')
+        subprocess.call(['sfnt2woff', fontfile + '.ttf'])
+    manifest['fonts'].append(fontfile + '.woff')
 
     # Convert EOT for IE7
-    subprocess.call('python ' + scriptPath + '/eotlitetool.py \'' + fontfile + '.ttf\' -o \'' + fontfile + '.eot\'', shell=True)
-    subprocess.call('mv \'' + fontfile + '.eotlite\' \'' + fontfile + '.eot\'', shell=True)
-    manifest['fonts'].append('\'' + fontfile + '.eot\'')
+    subprocess.call('python ' + scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -o ' + fontfile + '.eot', shell=True)
+    subprocess.call('mv ' + fontfile + '.eotlite ' + fontfile + '.eot', shell=True)
+    manifest['fonts'].append(fontfile + '.eot')
 
 finally:
     manifestfile.seek(0)


### PR DESCRIPTION
For anyone who got 'unexpected token' errors when using paths with special characters (creating EOT file doesn't work).

I just added marks around the `fontfile` paths and it works for now, but this error doesn't disappear: ` I'm sorry this file is too complex for me to understand (or is erroneous)`. Anyway, EOT files still working.

So I think it's not ready for merge but I don't know how to get rid of the warning.