### PR TITLE
set glyph name when creating char in fontforge

### DIFF
--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -63,7 +63,7 @@ def createGlyph( name, source, code ):
 
     if ext == '.svg':
         temp = removeSwitchFromSvg(source)
-        glyph = font.createChar(code)
+        glyph = font.createChar(code, name)
         glyph.importOutlines(temp)
         os.unlink(temp)
 


### PR DESCRIPTION
This will appear as `glyph-name=""`in the generated SVG font and is useful for e.g. use with services like Fontello.
