### PR TITLE
allow specification of copyright information

### DIFF
--- a/lib/fontcustom.rb
+++ b/lib/fontcustom.rb
@@ -38,6 +38,7 @@ module Fontcustom
     :no_hash => false,
     :debug => false,
     :force => false,
-    :quiet => false
+    :quiet => false,
+    :copyright => ''
   }
 end

--- a/lib/fontcustom/cli.rb
+++ b/lib/fontcustom/cli.rb
@@ -67,6 +67,9 @@ module Fontcustom
     class_option :quiet, :aliases => "-q", :type => :boolean,
       :desc => "Hide status messages."
 
+    class_option :copyright, :aliases => %w|--copyright -r|, :type => :string,
+      :desc => "Copyright information."
+
     # Required for Thor::Actions#template
     def self.source_root
       File.join Fontcustom.gem_lib, "templates"

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -39,6 +39,7 @@ font.descent = options['font_descent']
 font.fontname = options['font_name']
 font.familyname = options['font_name']
 font.fullname = options['font_name']
+font.copyright = options['copyright']
 if options['autowidth']:
     font.autoWidth(0, 0, options['font_em'])
 

--- a/lib/fontcustom/templates/fontcustom.yml
+++ b/lib/fontcustom/templates/fontcustom.yml
@@ -30,6 +30,9 @@
 # Hide status messages.
 #quiet: true
 
+# Copyright information.
+#copyright: 
+
 
 # -----------------------------------------------------------------------------
 # Input / Output Locations


### PR DESCRIPTION
This allows to customise the copyright message that FontForge sets in the generated fonts. Tested with CLI. I'm not sure if I'm missing some part regarding config file parsing.
