### PR TITLE
Be more unix-y and fail when there's an error

### DIFF
--- a/lib/fontcustom/cli.rb
+++ b/lib/fontcustom/cli.rb
@@ -78,6 +78,7 @@ module Fontcustom
     rescue Fontcustom::Error => e
       say_status :error, e.message, :red
       puts e.backtrace.join("\n") if options[:debug]
+      exit 1
     end
 
     desc "watch [INPUT] [OPTIONS]", "Watches INPUT for changes and regenerates files automatically. Ctrl + C to stop. Default: `pwd`"
@@ -90,6 +91,7 @@ module Fontcustom
       Watcher.new(opts).watch
     rescue Fontcustom::Error => e
       say_status :error, e.message, :red
+      exit 1
     end
 
     desc "config [DIR]", "Generates a starter configuration file (fontcustom.yml) in DIR. Default: `pwd`"


### PR DESCRIPTION
Right now if there's an error running a command, `fontcustom` will exit with a status code of `0`. This fixes it so that failures exit with a status code of `1`, so that `fontcustom` plays well with scripts and build tools that depend on it :)
