### PR TITLE
Added WOFF2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,14 @@ from a collection of SVGs
 
 ### Installation
 
-Requires **Ruby 1.9.2+**, **FontForge** with Python scripting.
+Requires **Ruby 1.9.2+**, **WOFF2**, **FontForge** with Python scripting.
 
 ```sh
 # On Mac
+brew tap bramstein/webfonttools
+brew update
+brew install woff2
+
 brew install fontforge --with-python
 brew install eot-utils
 gem install fontcustom
@@ -28,6 +32,7 @@ gem install fontcustom
 sudo apt-get install fontforge
 wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
 unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && sudo mv sfnt2woff /usr/local/bin/
+git clone --recursive https://github.com/google/woff2.git && cd woff2 && make clean all && sudo mv woff2_compress /usr/local/bin/ && sudo mv woff2_decompress /usr/local/bin/
 gem install fontcustom
 ```
 

--- a/lib/fontcustom/base.rb
+++ b/lib/fontcustom/base.rb
@@ -6,7 +6,8 @@ module Fontcustom
 
     def initialize(raw_options)
       check_fontforge
-      manifest = ".fontcustom-manifest.json"
+      check_woff2
+      manifest = '.fontcustom-manifest.json'
       raw_options[:manifest] = manifest
       @options = Fontcustom::Options.new(raw_options).options
       @manifest = Fontcustom::Manifest.new(manifest, @options)
@@ -33,6 +34,13 @@ module Fontcustom
       fontforge = `which fontforge`
       if fontforge == "" || fontforge == "fontforge not found"
         raise Fontcustom::Error, "Please install fontforge first. Visit <http://fontcustom.com> for instructions."
+      end
+    end
+
+    def check_woff2
+      woff2 = `which woff2_compress`
+      if woff2 == "" || woff2 == "woff2_compress not found"
+        fail Fontcustom::Error, "Please install woff2 first. Visit <https://github.com/google/woff2> for instructions."
       end
     end
 

--- a/lib/fontcustom/generator/template.rb
+++ b/lib/fontcustom/generator/template.rb
@@ -146,6 +146,7 @@ module Fontcustom
 @font-face {
   font-family: "#{font_name}";
   src: url("data:application/x-font-woff;charset=utf-8;base64,#{woff_base64}") format("woff"),
+       #{url}("#{path}.woff2") format("woff2"),
        #{url}("#{path}.ttf") format("truetype"),
        #{url}("#{path}.svg##{font_name}") format("svg");
   font-weight: normal;
@@ -156,6 +157,7 @@ module Fontcustom
   font-family: "#{font_name}";
   src: #{url}("#{path}.eot");
   src: #{url}("#{path}.eot?#iefix") format("embedded-opentype"),
+       #{url}("#{path}.woff2") format("woff2"),
        #{url}("#{path}.woff") format("woff"),
        #{url}("#{path}.ttf") format("truetype"),
        #{url}("#{path}.svg##{font_name}") format("svg");

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -125,6 +125,10 @@ try:
     subprocess.call('mv ' + fontfile + '.eotlite ' + fontfile + '.eot', shell=True)
     manifest['fonts'].append(fontfile + '.eot')
 
+    # Convert TTF to WOFF2
+    subprocess.call('woff2_compress \'' + fontfile + '.ttf\'', shell=True)
+    manifest['fonts'].append(fontfile + '.woff2')
+
 finally:
     manifestfile.seek(0)
     manifestfile.write(json.dumps(manifest, indent=2, sort_keys=True))


### PR DESCRIPTION
Requires WOFF2 tools
See build instructions at https://github.com/google/woff2
Fontcustom will produce fail if woff2_compres ulility is not installed

Added "woff2" installation instructions for Mac into Readme.md but actually not played with Mac. Hope it works.
