### PR TITLE
Remove CNAME with exprired domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-fontcustom.com


### PR DESCRIPTION
The project domain has expired - see issue #298 - and now the website http://fontcustom.com/ links to an auction where this domain is on sale.

I read about it in the comments to this answer on Stack Overflow:
http://stackoverflow.com/questions/11426172/add-custom-icons-to-font-awesome/14144910#14144910
Another comment there, as well PRs like Automattic/Genericons#92 suggest using the website https://fontcustom.github.io/fontcustom/ but it redirects to the expired domain's website, because of the CNAME file in the project's gh-pages branch.

Removing the CNAME should make the website accessible again.
