### PR TITLE
Allow sub-directories in input vectors

### DIFF
--- a/lib/fontcustom/base.rb
+++ b/lib/fontcustom/base.rb
@@ -38,7 +38,7 @@ module Fontcustom
 
     # Calculates a hash of vectors, options, and templates (content and filenames)
     def checksum
-      files = Dir.glob(File.join(@options[:input][:vectors], "*.svg")).select { |fn| File.file?(fn) }
+      files = Dir.glob(File.join(@options[:input][:vectors], "**/*.svg")).select { |fn| File.file?(fn) }
       files += Dir.glob(File.join(@options[:input][:templates], "*")).select { |fn| File.file?(fn) }
       content = files.map { |file| File.read(file) }.join
       content << files.join

--- a/lib/fontcustom/generator/font.rb
+++ b/lib/fontcustom/generator/font.rb
@@ -47,10 +47,10 @@ module Fontcustom
           0xf100
         end
 
-        files = Dir.glob File.join(@options[:input][:vectors], "*.svg")
+        files = Dir.glob File.join(@options[:input][:vectors], "**/*.svg")
         glyphs = {}
         files.each do |file|
-          name = File.basename file, ".svg"
+          name = file.sub(/^#{@options[:input][:vectors]}\/?/, '').sub(/\.svg$/, '')
           name = name.strip.gsub(/\W/, "-")
           glyphs[name.to_sym] = { :source => file }
           if File.read(file).include? "rgba"

--- a/lib/fontcustom/options.rb
+++ b/lib/fontcustom/options.rb
@@ -119,7 +119,7 @@ module Fontcustom
         @options[:input] = { :vectors => input, :templates => input }
       end
 
-      if Dir[File.join(@options[:input][:vectors], "*.svg")].empty?
+      if Dir.glob(File.join(@options[:input][:vectors], "**/*.svg")).empty?
         raise Fontcustom::Error, "`#{@options[:input][:vectors]}` doesn't contain any SVGs."
       end
     end


### PR DESCRIPTION
Recurse into input sub-directories instead of ignoring them.

This allows a better organization of your vectors.