### PR TITLE
add line-height to glyph's container

### DIFF
--- a/lib/fontcustom/generator/template.rb
+++ b/lib/fontcustom/generator/template.rb
@@ -181,11 +181,22 @@ module Fontcustom
         Base64.encode64(File.binread(File.join(woff_path))).gsub("\n", "")
       end
 
+      def glyph_container_selectors
+        output = @glyphs.map do |name, value|
+          @options[:css_selector].sub("{{glyph}}", name.to_s)
+        end
+        output.join ",\n"
+      end
+
       def glyph_selectors
         output = @glyphs.map do |name, value|
           @options[:css_selector].sub("{{glyph}}", name.to_s) + ":before"
         end
         output.join ",\n"
+      end
+
+      def glyph_container_properties
+%Q|  line-height: 1;|
       end
 
       def glyph_properties

--- a/lib/fontcustom/templates/_fontcustom-rails.scss
+++ b/lib/fontcustom/templates/_fontcustom-rails.scss
@@ -11,4 +11,9 @@
 <%= glyph_properties %>
 }
 
+[data-icon],
+<%= glyph_container_selectors %> {
+<%= glyph_container_properties %>
+}
+
 <%= glyphs %>

--- a/lib/fontcustom/templates/_fontcustom.scss
+++ b/lib/fontcustom/templates/_fontcustom.scss
@@ -11,6 +11,11 @@
 <%= glyph_properties %>
 }
 
+[data-icon],
+<%= glyph_container_selectors %> {
+<%= glyph_container_properties %>
+}
+
 <%= glyphs %>
 <% @glyphs.each do |name, value| %>
 $font-<%= font_name.gsub(/[^\w\d_]/, '-') %>-<%= name.to_s %>: "\<%= value[:codepoint].to_s(16) %>";<% end %>

--- a/lib/fontcustom/templates/fontcustom-preview.html
+++ b/lib/fontcustom/templates/fontcustom-preview.html
@@ -130,6 +130,11 @@
       <%= glyph_properties %>
       }
 
+      [data-icon],
+      <%= glyph_container_selectors %> {
+      <%= glyph_container_properties %>
+      }
+
       <%= glyphs %>
     </style>
 

--- a/lib/fontcustom/templates/fontcustom.css
+++ b/lib/fontcustom/templates/fontcustom.css
@@ -11,4 +11,9 @@
 <%= glyph_properties %>
 }
 
+[data-icon],
+<%= glyph_container_selectors %> {
+<%= glyph_container_properties %>
+}
+
 <%= glyphs %>


### PR DESCRIPTION
Doesn't look like the line-height on the glyph does anything, the container on the other hand removes unnecessary large spacing.

Left the line-height on the glyph for backward compatibility.