### PR TITLE
Fix warning message about default value for --templates

### DIFF
--- a/lib/fontcustom.rb
+++ b/lib/fontcustom.rb
@@ -19,7 +19,7 @@ module Fontcustom
   EXAMPLE_OPTIONS = {
     :output => "./FONT_NAME",
     :config => "./fontcustom.yml -or- ./config/fontcustom.yml",
-    :templates => "css preview"
+    :templates => %w|css preview|
   }
 
   DEFAULT_OPTIONS = {


### PR DESCRIPTION
Fixes https://github.com/FontCustom/fontcustom/issues/344 (seeing `Expected array default value for '--templates'; got "css preview" (string)` when running `fontcustom --version`)