### PR TITLE
Update README to Replace down url of sfnt2woff by sfnt2woff-zopfli.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ addons:
       - gcc-4.8
       - g++-4.8
 before_install:
-  - wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
-  - unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && mkdir -p bin && mv sfnt2woff bin && cd ..
-  - export PATH=$PATH:$PWD/sfnt2woff/bin/
+  - git clone https://github.com/bramstein/sfnt2woff-zopfli.git sfnt2woff-zopfli && cd sfnt2woff-zopfli && make && sudo mv sfnt2woff-zopfli /usr/local/bin/sfnt2woff
   - if [ $TRAVIS_OS_NAME == "linux" ]; then
       export CC="gcc-4.8";
       export CXX="g++-4.8";

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ gem install fontcustom
 
 # On Linux
 sudo apt-get install zlib1g-dev fontforge
-wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
-unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && sudo mv sfnt2woff /usr/local/bin/
+git clone https://github.com/bramstein/sfnt2woff-zopfli.git sfnt2woff-zopfli && cd sfnt2woff-zopfli && make && mv sfnt2woff-zopfli /usr/local/bin/sfnt2woff
 git clone --recursive https://github.com/google/woff2.git && cd woff2 && make clean all && sudo mv woff2_compress /usr/local/bin/ && sudo mv woff2_decompress /usr/local/bin/
 gem install fontcustom
 ```


### PR DESCRIPTION
README installation is outdated use [bramstein/sfnt2woff-zopfli](https://github.com/bramstein/sfnt2woff-zopfli).

Fixes #345.
Fixes #342.
Fixes #338.