### PR TITLE
Add SCSS vars for each glyph

### DIFF
--- a/lib/fontcustom/templates/_fontcustom-rails.scss
+++ b/lib/fontcustom/templates/_fontcustom-rails.scss
@@ -12,3 +12,6 @@
 }
 
 <%= glyphs %>
+<% @glyphs.each do |name, value| %>
+$font-<%= font_name.gsub(/[^\w\d_]/, '-') %>-<%= name.to_s %>: "\<%= value[:codepoint].to_s(16) %>";<% end %>
+                                                                                                     


### PR DESCRIPTION
The `scss-rails` template is missing the SCSS vars for each glyph