### PR TITLE
woff_path should from css option not fonts

### DIFF
--- a/lib/fontcustom/generator/template.rb
+++ b/lib/fontcustom/generator/template.rb
@@ -185,7 +185,7 @@ module Fontcustom
       end
 
       def woff_base64
-        woff_path = File.join(@options[:output][:fonts], "#{@font_path}.woff")
+        woff_path = File.join(@options[:output][:css], "#{@font_path}.woff")
         Base64.encode64(File.binread(File.join(woff_path))).gsub("\n", "")
       end
 


### PR DESCRIPTION
```ruby
        # we get @font_path base from css option
        fonts_path = Pathname.new(@options[:output][:fonts]).realdirpath
        css_path = Pathname.new(@options[:output][:css]).realdirpath
        preview_path = Pathname.new(@options[:output][:preview]).realdirpath
        @font_path = File.join fonts_path.relative_path_from(css_path).to_s, name

        # but we get woff_path base from fonts option
        def woff_base64
            woff_path = File.join(@options[:output][:fonts], "#{@font_path}.woff")
           Base64.encode64(File.binread(File.join(woff_path))).gsub("\n", "")
        end
```