### PR TITLE
gemspec: update json to 2.0

### DIFF
--- a/fontcustom.gemspec
+++ b/fontcustom.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "json", "~>1.4"
+  gem.add_dependency "json", "~>2.0"
   gem.add_dependency "thor", "~>0.14"
   gem.add_dependency "listen", ">=1.0","<4.0"
 


### PR DESCRIPTION
I am the Debian maintainer for fontcustom.

Fontcustom works with json 2.0 (as far as I tested).

This is needed for us to be able to test fontcustom in Debian, otherwise we get an error that complains about dependencies.