### PR TITLE
Use global sfnt2woff-zopfli in generate script

### DIFF
--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -120,9 +120,12 @@ try:
             subprocess.Popen([scriptPath + '/sfnt2woff', fontfile + '.ttf'], stdout=subprocess.PIPE)
     except OSError:
         # If the local version of sfnt2woff fails (i.e., on Linux), try to use the
-        # global version. This allows us to avoid forcing OS X users to compile
-        # sfnt2woff from source, simplifying install.
-        subprocess.call(['sfnt2woff', fontfile + '.ttf'])
+        # global version of sfnt2woff or sfnt2woff-zopfli. This allows us to avoid
+        # forcing OS X users to compile sfnt2woff from source, simplifying install.
+        try:
+            subprocess.call(['sfnt2woff-zopfli', fontfile + '.ttf'])
+        except OSError:
+            subprocess.call(['sfnt2woff', fontfile + '.ttf'])
     manifest['fonts'].append(fontfile + '.woff')
 
     # Convert EOT for IE7


### PR DESCRIPTION
In generate.py on Linux, try using the global `sfnt2woff-zopfli` before trying `sfnt2woff`. This catches cases where compilation would otherwise fail if the user only has `sfnt2woff-zopfli` installed and not `sfnt2woff`. (Also, on Ubuntu, the `sfnt2woff-zopfli` package is available in the repositories, but not `sfnt2woff`.)