### PR TITLE
Add required sfnt2woff homebrew package for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Requires **Ruby 1.9.3+**, **WOFF2**, **FontForge** with Python scripting.
 brew tap bramstein/webfonttools
 brew update
 brew install woff2
+brew install sfnt2woff
 
 brew install fontforge --with-python
 brew install eot-utils


### PR DESCRIPTION
Since OS X Catalina an extra package is required to install:
https://github.com/FontCustom/fontcustom/issues/382