### PR TITLE
Upgrade minimum required JSON version to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0 (9/20/2020)
+
+* Minimum JSON version bumped to 2.0.0
+
 ## 2.0.0 (6/14/2017)
 
 * Adds support for Woff2 ([#313](https://github.com/FontCustom/fontcustom/pull/313))

--- a/fontcustom.gemspec
+++ b/fontcustom.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "json", "~>1.4"
+  gem.add_dependency "json", "~>2.0.0"
   gem.add_dependency "thor", "~>0.14"
   gem.add_dependency "listen", ">=1.0","<4.0"
 

--- a/lib/fontcustom/version.rb
+++ b/lib/fontcustom/version.rb
@@ -1,3 +1,3 @@
 module Fontcustom
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
### JSON gem (v2.2.0 or prior) with ruby has **unsafe object creation vulnerability** [refer here](https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/)
 * upgraded JSON gem version from 1.4.0 to 2.0.0 (2.3.0 is preferred in users' applications to avoid security issues)
 * Bumped Fontcustom version to 2.1.0