### PR TITLE
Update json version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0 (11/8/2022)
+* Minimum json version bumped to 2.6.2
+
 ## 2.0.0 (6/14/2017)
 
 * Adds support for Woff2 ([#313](https://github.com/FontCustom/fontcustom/pull/313))

--- a/fontcustom.gemspec
+++ b/fontcustom.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "json", "~>1.4"
+  gem.add_dependency "json", "~>2.6.2"
   gem.add_dependency "thor", "~>0.14"
   gem.add_dependency "listen", ">=1.0","<4.0"
 

--- a/lib/fontcustom/version.rb
+++ b/lib/fontcustom/version.rb
@@ -1,3 +1,3 @@
 module Fontcustom
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Went with the latest version of the gem. All specs except one passed locally, but this spec also did not pass before updating and looks like it isn't `json` related?

```
1) Fontcustom::Watcher#watch should call generators when vectors change
     Failure/Error: Unable to find matching line from backtrace
       Exactly one instance should have received the following message(s) but didn't:
```