### PR TITLE
IT-1343: update to handle multiple python versions

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0 (11/8/2022)
+* Minimum json version bumped to 2.6.2
+
 ## 2.0.0 (6/14/2017)
 
 * Adds support for Woff2 ([#313](https://github.com/FontCustom/fontcustom/pull/313))

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,0 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-
-RSpec::Core::RakeTask.new "spec" do |s|
-  s.rspec_opts = "--color --format documentation"
-end
-
-task :default => :spec

--- a/fontcustom.gemspec
+++ b/fontcustom.gemspec
@@ -18,11 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "json", "~>1.4"
+  gem.add_dependency "json", "~>2.6.2"
   gem.add_dependency "thor", "~>0.14"
   gem.add_dependency "listen", ">=1.0","<4.0"
 
-  gem.add_development_dependency "rake", "~> 10"
-  gem.add_development_dependency "bundler"
   gem.add_development_dependency "rspec", "~>3.1.0"
 end

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -77,8 +77,8 @@ def createGlyph( name, source, code ):
             aligned_to_pixel_grid = (width % design_px == 0)
             if (aligned_to_pixel_grid):
                 shift = glyph.left_side_bearing % design_px
-                glyph.left_side_bearing = glyph.left_side_bearing - shift
-                glyph.right_side_bearing = glyph.right_side_bearing + shift
+                glyph.left_side_bearing = int(glyph.left_side_bearing) - int(shift)
+                glyph.right_side_bearing = int(glyph.right_side_bearing) + int(shift)
 
 # Add valid space glyph to avoid "unknown character" box on IE11
 glyph = font.createChar(32)

--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -126,7 +126,12 @@ try:
     manifest['fonts'].append(fontfile + '.woff')
 
     # Convert EOT for IE7
-    subprocess.call('python ' + scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -o ' + fontfile + '.eot', shell=True)
+    command_args = scriptPath + '/eotlitetool.py ' + fontfile + '.ttf -o ' + fontfile + '.eot'
+    process = subprocess.run('python ' + command_args, shell=True)
+    # Catch command not found error for python vs python3
+    if process.returncode == 127:
+        subprocess.run('python3 ' + command_args, shell=True, check=True)
+
     # check if windows
     if os.name == 'nt':
         subprocess.call('move ' + fontfile + '.eotlite ' + fontfile + '.eot', shell=True)

--- a/lib/fontcustom/version.rb
+++ b/lib/fontcustom/version.rb
@@ -1,3 +1,3 @@
 module Fontcustom
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/lib/fontcustom/version.rb
+++ b/lib/fontcustom/version.rb
@@ -1,3 +1,3 @@
 module Fontcustom
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
I don't have `python` in my path as I no longer have python2 installed. However I do have python3 which I believe is installed by mac by default as well.

Tested against my local setup before these changes, ` bundle exec fontcustom compile --debug` would return:
```       debug  Copyright (c) 2000-2023. See AUTHORS for Contributors.
               License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
               with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.
               Version: 20230101
               Based on sources from 2023-01-01 05:27 UTC-D.
              /bin/sh: python: command not found
              mv: rename stylesheets/icons.eotlite to stylesheets/icons.eot: No such file or directory
```
This produced no eot file due to the failure

After changes :
```       debug  Copyright (c) 2000-2023. See AUTHORS for Contributors.
               License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
               with many parts BSD <http://fontforge.org/license.html>. Please read LICENSE.
               Version: 20230101
               Based on sources from 2023-01-01 05:27 UTC-D.
              /bin/sh: python: command not found
              Compressed 23641 to 12607.
```

Note that it still says python not found (because python was not found and it fell back to python3)
However this does produce a valid eot file